### PR TITLE
Fix AES key encryption before exchange

### DIFF
--- a/service/src/cryptoAES.ts
+++ b/service/src/cryptoAES.ts
@@ -1,6 +1,8 @@
 /**
  * Symmetric key encryption used for encrypting Audio/Video data
  */
+import { cryptoUtils } from './cryptoRSA';
+
 export class AesGcmEncryption {
     private aesKeyLocal?: CryptoKey;
     private aesKeyRemote?: CryptoKey;
@@ -27,17 +29,15 @@ export class AesGcmEncryption {
     }
 
     /**
-     * To Do: 
-     * this key is plain text, can be used to decrypt data.
-     * Should not be transmitted over network.
-     * Use cryptoUtils to encrypt the key and exchange.
+     * The AES key is now encrypted before transmission.
      */
-    public async getRawAesKeyToExport(): Promise<string> {
+    public async getRawAesKeyToExport(publicKey: string): Promise<string> {
         if(!this.aesKeyLocal) {
             throw new Error('AES key not generated');
         }
         const jsonWebKey = await crypto.subtle.exportKey("jwk", this.aesKeyLocal);
-        return JSON.stringify(jsonWebKey);
+        const aesKeyString = JSON.stringify(jsonWebKey);
+        return cryptoUtils.encryptMessage(aesKeyString, publicKey);
     }
 
     public async setRemoteAesKey(key: string): Promise<void> {

--- a/service/src/sdk.ts
+++ b/service/src/sdk.ts
@@ -145,9 +145,10 @@ class ChatE2EE implements IChatE2EE {
         this.channelId = channelId;
         this.userId = userId;
 
-        const aesPlain = await this.symEncryption.getRawAesKeyToExport();
+        const aesPlain = await this.symEncryption.getRawAesKeyToExport(this.publicKey);
+        const encryptedAesKey = await _cryptoUtils.encryptMessage(aesPlain, this.publicKey);
 
-        await sharePublicKey({ aesKey: aesPlain, publicKey: this.publicKey, sender: this.userId, channelId: this.channelId});
+        await sharePublicKey({ aesKey: encryptedAesKey, publicKey: this.publicKey, sender: this.userId, channelId: this.channelId});
         this.socket.joinChat({ publicKey: this.publicKey, userID: this.userId, channelID: this.channelId})
         await this.getPublicKey(logger);
         return;


### PR DESCRIPTION
Fixes #1


Encrypt the AES key using cryptoUtils.encryptMessage in getRawAesKeyToExport method

Update the comment to reflect that the AES key is now encrypted before transmission


Add item

Encrypt the AES key using cryptoUtils.encryptMessage before sending it to the server in setChannel method

Update the setChannel method to send the encrypted AES key to the server using sharePublicKey

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/R00tedbrain/chat-e2eeBWT/issues/1?shareId=ca4f5e77-bf19-4859-bcac-5d94e4f0ba68).