### PR TITLE
Fix ReactDOM.render warning in React 18

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client"; // P36ce
 // import styles from '@Style.module.css';
 import styles from "./Style.module.css";
 
@@ -28,9 +28,10 @@ const App = () => {
   );
 };
 
-ReactDOM.render(
+const container = document.getElementById("root");
+const root = createRoot(container!); // P4673
+root.render(
   <ThemeProvider>
     <App />
-  </ThemeProvider>,
-  document.getElementById("root")
+  </ThemeProvider>
 );


### PR DESCRIPTION
Related to #10

Update `client/src/index.tsx` to use `createRoot` from `react-dom/client` instead of `ReactDOM.render`.

* Import `createRoot` from `react-dom/client`.
* Replace `ReactDOM.render` with `createRoot` to render the `App` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/R00tedbrain/chat-e2eeBWT/issues/10?shareId=60f19d34-07bd-4863-9a1c-98271fc2c8cb).