### PR TITLE
Fix unhandled promise rejection error

### DIFF
--- a/service/src/publicKey.ts
+++ b/service/src/publicKey.ts
@@ -1,20 +1,30 @@
 import makeRequest from './makeRequest';
 import { IGetPublicKeyReturn } from './public/types';
 
-export const sharePublicKey = ({ aesKey, publicKey, sender, channelId }) => {
-  return makeRequest('chat/share-public-key', {
-    method: 'POST',
-    body: {
-      aesKey,
-      publicKey,
-      sender,
-      channel: channelId
-    }
-  });
+export const sharePublicKey = async ({ aesKey, publicKey, sender, channelId }) => {
+  try {
+    return await makeRequest('chat/share-public-key', {
+      method: 'POST',
+      body: {
+        aesKey,
+        publicKey,
+        sender,
+        channel: channelId
+      }
+    });
+  } catch (error) {
+    console.error('Error sharing public key:', error);
+    throw error;
+  }
 };
 
-export const getPublicKey = ({ userId, channelId }): Promise<IGetPublicKeyReturn> => {
-  return makeRequest(`chat/get-public-key/?userId=${userId}&channel=${channelId}&timeStamp=${Date.now()}`, {
-    method: 'GET'
-  });
+export const getPublicKey = async ({ userId, channelId }): Promise<IGetPublicKeyReturn> => {
+  try {
+    return await makeRequest(`chat/get-public-key/?userId=${userId}&channel=${channelId}&timeStamp=${Date.now()}`, {
+      method: 'GET'
+    });
+  } catch (error) {
+    console.error('Error getting public key:', error);
+    throw error;
+  }
 };

--- a/service/src/sdk.ts
+++ b/service/src/sdk.ts
@@ -252,11 +252,16 @@ class ChatE2EE implements IChatE2EE {
     //get receiver public key
     private async getPublicKey(logger: Logger): Promise<void> {
         logger.log(`getPublicKey()`);
-        const receiverPublicKey = await getPublicKey({ userId: this.userId, channelId: this.channelId });
-        logger.log(`setPublicKey() - ${!!receiverPublicKey?.publicKey}`);
-        this.receiverPublicKey = receiverPublicKey?.publicKey;
-        if(receiverPublicKey.aesKey) {
-            await this.symEncryption.setRemoteAesKey(receiverPublicKey.aesKey)
+        try {
+            const receiverPublicKey = await getPublicKey({ userId: this.userId, channelId: this.channelId });
+            logger.log(`setPublicKey() - ${!!receiverPublicKey?.publicKey}`);
+            this.receiverPublicKey = receiverPublicKey?.publicKey;
+            if(receiverPublicKey.aesKey) {
+                await this.symEncryption.setRemoteAesKey(receiverPublicKey.aesKey)
+            }
+        } catch (error) {
+            logger.log('Error getting public key:', error);
+            throw error;
         }
         return;
     }
@@ -280,7 +285,7 @@ class ChatE2EE implements IChatE2EE {
             this.channelId, 
             this.callLogger,
         );
-        this.setupCallSubs(this.call)
+        this.setupCallSubs(this.call);
         return this.call;
     }
 }

--- a/service/src/utils/logger.ts
+++ b/service/src/utils/logger.ts
@@ -28,10 +28,15 @@ export class Logger {
             // set disableLog: false in configContext to enable logs
             return;
         }
-        if(this.counter) {
-            console.log(`${this.logTitle}$${this.counter}`, ...args);
-        }else {
-            console.log(`${this.logTitle}`, ...args);
+        try {
+            if(this.counter) {
+                console.log(`${this.logTitle}$${this.counter}`, ...args);
+            }else {
+                console.log(`${this.logTitle}`, ...args);
+            }
+        } catch (error) {
+            console.error('Error logging message:', error);
+            throw error;
         }
     }
 


### PR DESCRIPTION
Fixes #15

Add error handling for promise rejections in `publicKey.ts`, `sdk.ts`, and `logger.ts`.

* **publicKey.ts**
  - Add a try-catch block to handle promise rejections in the `sharePublicKey` function.
  - Add a try-catch block to handle promise rejections in the `getPublicKey` function.

* **sdk.ts**
  - Add a try-catch block to handle promise rejections in the `getPublicKey` function.

* **logger.ts**
  - Add a try-catch block to handle promise rejections in the `log` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/R00tedbrain/chat-e2eeBWT/issues/15?shareId=378a5968-0959-4ca4-9e33-7c7261f7e439).